### PR TITLE
Create version of Dockerfile containing python

### DIFF
--- a/circle-ci-node-aws/Dockerfile
+++ b/circle-ci-node-aws/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:16.15
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+RUN apt-get update
+RUN apt-get install \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release -y
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update
+RUN apt-get install docker-ce-cli -y

--- a/circle-ci-node-aws/python/Dockerfile
+++ b/circle-ci-node-aws/python/Dockerfile
@@ -1,14 +1,25 @@
-FROM node:16.15
+FROM python:3.8.12
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
 RUN apt-get update
 RUN apt-get install \
     ca-certificates \
     curl \
+    unzip \
     gnupg \
     lsb-release -y
+
+# Install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+
+
+# Install Node 16
+RUN apt-get update
+RUN curl -sL https://deb.nodesource.com/setup_16.17 | bash -
+RUN apt -y install nodejs
+
+# Install docker
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 RUN echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \

--- a/circle-ci-node-aws/python/Dockerfile
+++ b/circle-ci-node-aws/python/Dockerfile
@@ -16,7 +16,7 @@ RUN ./aws/install
 
 # Install Node 16
 RUN apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_16.17 | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt -y install nodejs
 
 # Install docker


### PR DESCRIPTION
Create a version of the Dockerfile containing python which is needed for example for the image-post-processing deploy.
