### PR TITLE
[INT-1135] Copying over cups configuration file, instead of mutating created one

### DIFF
--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -23,20 +23,8 @@ RUN chmod +rx /tini
 ADD drivers ./drivers
 RUN cd ./drivers && tar -zxvf cupsdriver-1.2-56.tar.gz && cd cupsdriver-1.2-56 && ./build.sh
 
-# increase max jobs in queue (from default 500) to handle large batches (e.g. freight labels for standard containers)
-# adds "MaxJobs 10000" to first line of cupsd.conf
-RUN sed -i '1s/^/MaxJobs 10000\n/' /etc/cups/cupsd.conf
-
-# Finally fixed the issue that I attempted to fix in
-# https://github.com/sellpy/sellpy-dockerfiles/commit/b573e7eb300b6fd93a793852f5928755402e120a (and made a workaround in later commits)
-# The issue was that a bug (https://bugs.launchpad.net/ubuntu/+source/cups/+bug/1747765)
-# was corrected in (https://launchpad.net/ubuntu/+source/cups/2.1.3-4ubuntu0.9) which made the "seconds" value to be working correctly
-# for PreserveJobFiles. And since the default value was 86400 (1 day) it broke our counter "Jobs in the printer queue".
-RUN sed -i '1s/^/PreserveJobFiles No\n/' /etc/cups/cupsd.conf
-
-# Also delete job history (d* files in /var/spool/cups are JobFiles and c* are JobHistory)
-# Delete in order to prevent memory usage from spiking resulting in slow prints (especially when MaxJobs was increased from 500 to 10000)
-RUN sed -i '1s/^/PreserveJobHistory No\n/' /etc/cups/cupsd.conf
+# Copy local configuration file to container
+COPY cupsd.conf /etc/cups/
 
 ENTRYPOINT ["/tini", "--"]
 CMD ["/usr/sbin/cupsd", "-f"]

--- a/cups/cupsd.conf
+++ b/cups/cupsd.conf
@@ -1,0 +1,111 @@
+# Also delete job history (d* files in /var/spool/cups are JobFiles and c* are JobHistory)
+# Delete in order to prevent memory usage from spiking resulting in slow prints (especially when MaxJobs was increased from 500 to 10000)
+PreserveJobHistory No
+PreserveJobFiles No
+
+# increase max jobs in queue (from default 500) to handle large batches (e.g. freight labels for standard containers)
+MaxJobs 10000
+
+# Configuration file for the CUPS scheduler.  See "man cupsd.conf" for a
+# complete description of this file.
+
+# Log general information in error_log - change "warn" to "debug"
+# for troubleshooting...
+LogLevel warn
+PageLogFormat
+
+# Deactivate CUPS' internal logrotating, as we provide a better one, especially
+# LogLevel debug2 gets usable now
+MaxLogSize 0
+
+# Only listen for connections from the local machine.
+Listen localhost:631
+Listen /var/run/cups/cups.sock
+
+# Show shared printers on the local network.
+Browsing Off
+BrowseLocalProtocols dnssd
+
+# Default authentication type, when authentication is required...
+DefaultAuthType Basic
+
+# Web interface setting...
+WebInterface Yes
+
+# Restrict access to the server...
+<Location />
+  Order allow,deny
+</Location>
+
+# Restrict access to the admin pages...
+<Location /admin>
+  Order allow,deny
+</Location>
+
+# Restrict access to configuration files...
+<Location /admin/conf>
+  AuthType Default
+  Require user @SYSTEM
+  Order allow,deny
+</Location>
+
+# Restrict access to log files...
+<Location /admin/log>
+  AuthType Default
+  Require user @SYSTEM
+  Order allow,deny
+</Location>
+
+# Set the default printer/job policies...
+<Policy default>
+  <Limit All>
+    Order allow,deny
+    Allow all
+  </Limit>
+</Policy>
+
+# Set the authenticated printer/job policies...
+<Policy authenticated>
+  # Job/subscription privacy...
+  JobPrivateAccess default
+  JobPrivateValues default
+  SubscriptionPrivateAccess default
+  SubscriptionPrivateValues default
+
+  # Job-related operations must be done by the owner or an administrator...
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    AuthType Default
+    Order deny,allow
+  </Limit>
+
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All administration operations require an administrator to authenticate...
+  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All printer operations require a printer operator to authenticate...
+  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # Only the owner or an administrator can cancel or authenticate a job...
+  <Limit Cancel-Job CUPS-Authenticate-Job>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  <Limit All>
+    Order deny,allow
+  </Limit>
+</Policy>


### PR DESCRIPTION
Had some problems with new issues not being installed correctly for new sites (`lpadmin unauthorized` issues). What I did to solve it haphazardly was to tinker around with the cups configuration files inside the CUPS docker container on these hosts. The configuration that finally worked in order to skip authentication was this one that I added to the repo. Basically, the section that removes requirement for CUPS authentication is this one:
```
# Set the default printer/job policies...
<Policy default>
  <Limit All>
    Order allow,deny
    Allow all
  </Limit>
</Policy>
```

So instead of doing some pretty complex pattern-matching in order to find the previous section, it felt easier to just copy the working configuration file here and just copy it over to the container upon creation. Also removed the `Dockerfile` instructions where contents were copied over, and added them to the 'static' configuration file instead.