### PR TITLE
[INT-1849] Moving building of Docker images, Docker Hub :arrow_right: GitHub

### DIFF
--- a/.github/workflows/build_cups_docker.yml
+++ b/.github/workflows/build_cups_docker.yml
@@ -10,6 +10,8 @@ jobs:
   build_job:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4      
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -21,7 +23,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ${{ github.workspace }}/cups
-          file: ${{ github.workspace }}/cups/Dockerfile
+          context: ./cups
+          file: ./cups/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/build_cups_docker.yml
+++ b/.github/workflows/build_cups_docker.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ./cups
-          file: ./cups/Dockerfile
+          context: ${{ github.workspace }}/cups
+          file: ${{ github.workspace }}/cups/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/build_cups_docker.yml
+++ b/.github/workflows/build_cups_docker.yml
@@ -3,7 +3,7 @@ run-name: Building CUPS docker image and pushing it to GitHub registry
 on:
   push:
     branches:
-      - master
+      - github-docker-builds
     paths:
       - "cups/**"
 jobs:

--- a/.github/workflows/build_cups_docker.yml
+++ b/.github/workflows/build_cups_docker.yml
@@ -3,13 +3,14 @@ run-name: Building CUPS docker image and pushing it to GitHub registry
 on:
   push:
     branches:
-      - github-docker-builds
+      - master
     paths:
       - "cups/**"
 jobs:
   build_job:
     runs-on: ubuntu-latest
     steps:
+      # Checkout step usually not needed when using docker/build-push-action@v6, but necessary for using the relative paths in order to find the correct Dockerfile.
       - name: Checkout repo
         uses: actions/checkout@v4      
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build_cups_docker.yml
+++ b/.github/workflows/build_cups_docker.yml
@@ -1,0 +1,25 @@
+name: build-cups-docker
+run-name: Building CUPS docker image and pushing it to GitHub registry
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "cups/**"
+jobs:
+  build_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx # Needed by docker/build-push-action@v6 
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/build_cups_docker.yml
+++ b/.github/workflows/build_cups_docker.yml
@@ -21,5 +21,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          context: ./cups
+          file: ./cups/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}:latest

--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -11,7 +11,6 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 ENV TERM xterm
-ENV foobar hejhej
 
 ADD install.sh /tmp/install.sh
 RUN sh -e /tmp/install.sh

--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -11,6 +11,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 ENV TERM xterm
+ENV foobar hejhej
 
 ADD install.sh /tmp/install.sh
 RUN sh -e /tmp/install.sh


### PR DESCRIPTION
Reasoning described in [photo-robot-node PR](https://github.com/sellpy/photo-robot-node/pull/89).
* Added new Docker build workflow. Building on pushes to `master` branch, and tagging with `:latest`. Some magic needed in order to build only the `cups` application, so the workflow differs a tiny bit from the others.